### PR TITLE
Add alert for Mail sending alert failures

### DIFF
--- a/alerts/Mail_relay_denied.yaml
+++ b/alerts/Mail_relay_denied.yaml
@@ -1,0 +1,21 @@
+name: Relay access denied for Alerts
+type: frequency
+index: filebeat-*
+num_events: 50
+timeframe:
+    minutes: 10
+filter:
+- term:
+    application: "mail"
+- match:
+    message:
+        query: "Relay access denied"
+        operator: "and"
+- match:
+    message:
+        query: "proto=ESMTP helo=<smtp.devex.io>"
+        operator: "and"
+alert:
+- "email"
+email:
+- "prod-infra@devex.com"


### PR DESCRIPTION
This yaml file is the configuration we add to logit's alerts in
Production stack so we are alerted if the mail server starts refusing
to relay mail.

This was the cause of the Business Alerts failure on 24th April and
May 2nd.