### PR TITLE
Add BA groks to grape.log processing

### DIFF
--- a/logstash/8e9b1edc-5e4e-4677-9fb1-405d435f1d44/config.cfg
+++ b/logstash/8e9b1edc-5e4e-4677-9fb1-405d435f1d44/config.cfg
@@ -26,7 +26,7 @@ if [type] == "unicorn" {
 if [application] == "grape" {
   grok {
     patterns_dir => '/cusdata/patterns'
-    match => { "message" => "%{GRAPE_API}" }
+    match => { "message" => "%{GRAPE_API}|%{GRAPE_API_ALERTS}" }
   }
   date {
     match => [ "timestamp", "MM/dd HH:mm:ss", "YYYY-MM-dd'T'HH:mm:ss.SSSSSS", "YYYY-MM-dd'T'HH:mm:ss.SSSSSSZ", "YYYY-MM-dd'T'HH:mm:ss.SSSSSSZZ" ]


### PR DESCRIPTION
The parallel Alerts are logging in grape.log instead of the usual
place. Let's keep analyzing the strings, please.