### PR TITLE
DVX-6894 Fix use of GREEDYDATA grok pattern in grafana

### DIFF
--- a/patterns/grafana
+++ b/patterns/grafana
@@ -1,3 +1,3 @@
-GRAFANA_LOG_ENTRY t=%{TIMESTAMP_ISO8601:event_timestamp} lvl=%{LOGLEVEL:level} msg=%{GREEDYDATA:message} logger=%{GREEDYDATA:logger} userId=%{NUMBER:user_id:int} orgId=%{NUMBER:org_id:int} uname=%{GREEDYDATA:uname} method=%{HTTP_METHOD:method} path=%{PATH:path} status=%{NUMBER:status:int} remote_addr=%{IP:remote_addr} time_ms=%{NUMBER:time} size=%{NUMBER:size:int} referer=%{URI:referer}
+GRAFANA_LOG_ENTRY t=%{TIMESTAMP_ISO8601:event_timestamp} lvl=%{LOGLEVEL:level} %{GREEDYDATA:message}
 
 GRAFANA_LOG %{GRAFANA_LOG_ENTRY}


### PR DESCRIPTION
Current grafana grok patterns are failing on catching
unwanted data. This will fix the grok parser errors.

Refs [DVX-6894](https://mydevex.atlassian.net/browse/DVX-6894)